### PR TITLE
[Bugfix] Parse wrong RequestKey value

### DIFF
--- a/AspNetScaffolding3/Extensions/Queue/QueueClient.cs
+++ b/AspNetScaffolding3/Extensions/Queue/QueueClient.cs
@@ -182,11 +182,17 @@ namespace AspNetScaffolding.Extensions.Queue
             }
 
             object requestKeyHeader = null;
+            string requestKey = null;
             try
             {
                 if (eventArgs.BasicProperties.Headers?.ContainsKey("request_key") == true)
                 {
                     eventArgs.BasicProperties.Headers.TryGetValue("request_key", out requestKeyHeader);
+                }
+                
+                if (requestKeyHeader != null)
+                {
+                    requestKey = Encoding.UTF8.GetString((byte[])requestKeyHeader);
                 }
             }
             catch (Exception)
@@ -198,7 +204,7 @@ namespace AspNetScaffolding.Extensions.Queue
 
             var message = Encoding.UTF8.GetString(eventArgs.Body);
 
-            await this.ReceiveMessage?.Invoke(message, retryCount, eventArgs.DeliveryTag, requestKeyHeader?.ToString());
+            await this.ReceiveMessage?.Invoke(message, retryCount, eventArgs.DeliveryTag, requestKey);
         }
 
         public void Dispose()


### PR DESCRIPTION
![Git Merge](https://media.giphy.com/media/cFkiFMDg3iFoI/giphy.gif)

### Status

READY

### Whats?

Was converting the wrong bytes code when getting the requestKey

### Why?

Now we transform the object to bytes and convert it with Encoding.UTF8.GetString
