### PR TITLE
✨ Updates serilog and adds new blacklists

### DIFF
--- a/AspNetScaffolding3.DemoApi/AspNetScaffolding3.DemoApi.csproj
+++ b/AspNetScaffolding3.DemoApi/AspNetScaffolding3.DemoApi.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Mongo.CRUD" Version="1.1.0" />
     <PackageReference Include="PackUtils" Version="1.5.1" />
     <PackageReference Include="PeriodicBatching" Version="1.1.0" />
-    <PackageReference Include="RestSharp.Easy" Version="1.5.1-preview.3" />
+    <PackageReference Include="RestSharp.Easy" Version="1.5.1" />
     <PackageReference Include="WebApi.Models" Version="1.1.0" />
   </ItemGroup>
 

--- a/AspNetScaffolding3.DemoApi/Controllers/CustomerController.cs
+++ b/AspNetScaffolding3.DemoApi/Controllers/CustomerController.cs
@@ -74,9 +74,9 @@ namespace AspNetScaffolding.Controllers
         [ProducesResponseType(typeof(ErrorsResponse), 400)]
         [ProducesResponseType(404)]
         [ProducesResponseType(500)]
-        public IActionResult GetString([FromRoute] string customerId)
+        public IActionResult GetString([FromRoute] string customerId, [FromQuery] string customerKey)
         {
-            return Ok(new { customerId });
+            return Ok(new { customerId, customerKey });
         }
 
         [HttpGet("customers/{customerId}/none")]

--- a/AspNetScaffolding3.DemoApi/appsettings.json
+++ b/AspNetScaffolding3.DemoApi/appsettings.json
@@ -89,6 +89,8 @@
     "TitlePrefix": "[{Application}] ",
     "JsonBlacklistRequest": [ "*password", "*card.number", "*creditcardnumber", "*cvv", "*only_request" ],
     "JsonBlacklistResponse": [ "*password", "*card.number", "*creditcardnumber", "*cvv", "*only_response" ],
+    "HeaderBlacklist": [ "Authorization" ],
+    "QueryStringBlacklist": [ "customer_key" ],
     "SeqOptions": {
       "Enabled": true,
       "MinimumLevel": "Verbose",

--- a/AspNetScaffolding3/AspNetScaffolding3.csproj
+++ b/AspNetScaffolding3/AspNetScaffolding3.csproj
@@ -36,7 +36,7 @@
     <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="3.1.1" />
     <PackageReference Include="AspNetCore.HealthChecks.Uris" Version="3.1.2" />
     <PackageReference Include="AspNetCoreRateLimit" Version="3.2.2" />
-    <PackageReference Include="AspNetSerilog" Version="1.4.0" />
+    <PackageReference Include="AspNetSerilog" Version="1.5.0" />
     <PackageReference Include="AutoMapper" Version="9.0.0" />
     <PackageReference Include="CQRS.Extensions" Version="3.0.6" />
     <PackageReference Include="CQRS.Extensions.AspNetMVC" Version="3.0.6" />
@@ -54,8 +54,8 @@
     <PackageReference Include="PeriodicBatching" Version="1.1.0" />
     <PackageReference Include="PipelineR" Version="1.6.0" />
     <PackageReference Include="RedLock.net" Version="2.3.1" />
-    <PackageReference Include="RestSharp.Easy" Version="1.5.1-preview.3" />
-    <PackageReference Include="RestSharp.Serilog.Auto" Version="1.3.0" />
+    <PackageReference Include="RestSharp.Easy" Version="1.5.1" />
+    <PackageReference Include="RestSharp.Serilog.Auto" Version="1.4.0" />
     <PackageReference Include="Serilog.Builder" Version="1.4.0-preview.1" />
     <PackageReference Include="SqlClient.ParseToObject" Version="1.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.5.1" />

--- a/AspNetScaffolding3/Extensions/Logger/LoggerService.cs
+++ b/AspNetScaffolding3/Extensions/Logger/LoggerService.cs
@@ -47,6 +47,8 @@ namespace AspNetScaffolding.Extensions.Logger
                 ErrorTitle = settings?.TitlePrefix + CommunicationLogger.DefaultErrorTitle,
                 BlacklistRequest = settings?.GetJsonBlacklistRequest(),
                 BlacklistResponse = settings?.JsonBlacklistResponse,
+                HeaderBlacklist = settings?.HeaderBlacklist,
+                QueryStringBlacklist = settings?.QueryStringBlacklist,
                 RequestKeyProperty = RequestKeyServiceExtension.RequestKeyHeaderName,
                 AccountIdProperty = AccountIdServiceExtension.AccountIdHeaderName,
                 TimeElapsedProperty = TimeElapsedServiceExtension.TimeElapsedHeaderName,

--- a/AspNetScaffolding3/Extensions/Logger/LoggerSettings.cs
+++ b/AspNetScaffolding3/Extensions/Logger/LoggerSettings.cs
@@ -28,6 +28,10 @@ namespace AspNetScaffolding.Extensions.Logger
 
         public string[] JsonBlacklistResponse { get; set; }
 
+        public string[] HeaderBlacklist { get; set; }
+
+        public string[] QueryStringBlacklist { get; set; }
+
         public bool DebugEnabled { get; set; }
 
         public SeqOptions SeqOptions { get; set; } = new SeqOptions();


### PR DESCRIPTION
### Whats?

Implements a way to mask fields in the query string and headers.

### Why?

Because it is needed to mask some fields when logging not only in the request but other fields too.

### How?

Added new methods to handle the field masking. 
Added fields in the configuration file to store and separate the fields that we need to mask.