### PR TITLE
:sparkles: Add rate limiting by url resource

### DIFF
--- a/AspNetScaffolding3/Api.cs
+++ b/AspNetScaffolding3/Api.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using System;
 using System.IO;
+using AspNetScaffolding3.Extensions.RequestLimit;
 
 namespace AspNetScaffolding
 {
@@ -30,7 +31,7 @@ namespace AspNetScaffolding
 
         public static ShutdownSettings ShutdownSettings { get; set; } = new ShutdownSettings();
 
-        public static IpRateLimitingAdditional IpRateLimitingAdditional { get; set; } = new IpRateLimitingAdditional();
+        public static RateLimitingAdditional RateLimitingAdditional { get; set; } = new RateLimitingAdditional();
 
         public static CacheSettings CacheSettings { get; set; } = new CacheSettings();
 

--- a/AspNetScaffolding3/Extensions/JsonSerializer/CaseUtility.cs
+++ b/AspNetScaffolding3/Extensions/JsonSerializer/CaseUtility.cs
@@ -8,6 +8,11 @@ namespace AspNetScaffolding.Extensions.JsonSerializer
 
         public static string GetValueConsideringCurrentCase(this string value)
         {
+            if (string.IsNullOrEmpty(value))
+            {
+                return string.Empty;
+            }
+
             return value.ToCase(JsonSerializerMode.ToString());
         }
     }

--- a/AspNetScaffolding3/Extensions/RequestLimit/CustomRateLimitConfiguration.cs
+++ b/AspNetScaffolding3/Extensions/RequestLimit/CustomRateLimitConfiguration.cs
@@ -1,0 +1,23 @@
+﻿using AspNetCoreRateLimit;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+
+namespace AspNetScaffolding3.Extensions.RequestLimit
+{
+    public class CustomRateLimitConfiguration : RateLimitConfiguration
+    {
+        public CustomRateLimitConfiguration(
+            IHttpContextAccessor httpContextAccessor,
+            IOptions<IpRateLimitOptions> ipOptions,
+            IOptions<ClientRateLimitOptions> clientOptions) : base(httpContextAccessor, ipOptions, clientOptions)
+        {
+        }
+
+        protected override void RegisterResolvers()
+        {
+            base.RegisterResolvers();
+
+            ClientResolvers.Add(new UrlResourceRateLimitContributor(HttpContextAccessor));
+        }
+    }
+}

--- a/AspNetScaffolding3/Extensions/RequestLimit/IpRateLimitingService.cs
+++ b/AspNetScaffolding3/Extensions/RequestLimit/IpRateLimitingService.cs
@@ -1,6 +1,6 @@
 ﻿using AspNetCoreRateLimit;
 using AspNetScaffolding.Extensions.Cache;
-using AspNetScaffolding.Extensions.RequestLimit;
+using AspNetScaffolding3.Extensions.RequestLimit;
 using Microsoft.Extensions.DependencyInjection;
 using System;
 
@@ -10,20 +10,30 @@ namespace AspNetScaffolding.Extensions.RequestLimit
     {
         public static void SetupIpRateLimiting(
             this IServiceCollection services,
-            IpRateLimitingAdditional ipRateLimitingAdditional,
+            RateLimitingAdditional rateLimitingAdditional,
             CacheSettings cacheSettings)
         {
-            if (ipRateLimitingAdditional?.Enabled == true)
+            if (rateLimitingAdditional?.Enabled == true)
             {
                 if (cacheSettings?.Enabled != true)
                 {
                     throw new ArgumentException("CacheSettings must be enabled to use IpRateLimit");
                 }
 
-                services.Configure<IpRateLimitOptions>(Api.ConfigurationRoot.GetSection("IpRateLimiting"));
-                services.Configure<IpRateLimitPolicies>(Api.ConfigurationRoot.GetSection("IpRateLimitPolicies"));
+                if (rateLimitingAdditional.ByUrlResource)
+                {
+                    services.Configure<IpRateLimitOptions>(Api.ConfigurationRoot.GetSection("RateLimiting"));
+                    services.Configure<IpRateLimitPolicies>(Api.ConfigurationRoot.GetSection("RateLimitPolicies"));
+                    services.AddSingleton<IRateLimitConfiguration, CustomRateLimitConfiguration>();
+                    UrlResourceRateLimitContributor.UrlResource = rateLimitingAdditional.UrlResource;
+                }
+                else 
+                {
+                    services.Configure<IpRateLimitOptions>(Api.ConfigurationRoot.GetSection("IpRateLimiting"));
+                    services.Configure<IpRateLimitPolicies>(Api.ConfigurationRoot.GetSection("IpRateLimitPolicies"));
+                    services.AddSingleton<IRateLimitConfiguration, RateLimitConfiguration>();
+                }
                 
-
                 if (cacheSettings.UseRedis)
                 {
                     services.AddSingleton<IIpPolicyStore, DistributedCacheIpPolicyStore>();
@@ -34,8 +44,6 @@ namespace AspNetScaffolding.Extensions.RequestLimit
                     services.AddSingleton<IIpPolicyStore, MemoryCacheIpPolicyStore>();
                     services.AddSingleton<IRateLimitCounterStore, MemoryCacheRateLimitCounterStore>();
                 }
-
-                services.AddSingleton<IRateLimitConfiguration, RateLimitConfiguration>();
             }
         }
     }

--- a/AspNetScaffolding3/Extensions/RequestLimit/RateLimitingAdditional.cs
+++ b/AspNetScaffolding3/Extensions/RequestLimit/RateLimitingAdditional.cs
@@ -1,0 +1,14 @@
+﻿namespace AspNetScaffolding3.Extensions.RequestLimit
+{
+    /// <summary>
+    /// Was created only to keep retrocompatibility with older verions. This could be the same as the IpRateLimitingAdditional class
+    /// </summary>
+    public class RateLimitingAdditional
+    {
+        public bool Enabled { get; set; }
+
+        public bool ByUrlResource { get; set; }
+
+        public string UrlResource { get; set; }
+    }
+}

--- a/AspNetScaffolding3/Extensions/RequestLimit/UrlResourceRateLimitContributor.cs
+++ b/AspNetScaffolding3/Extensions/RequestLimit/UrlResourceRateLimitContributor.cs
@@ -1,0 +1,38 @@
+﻿using AspNetCoreRateLimit;
+using Microsoft.AspNetCore.Http;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace AspNetScaffolding3.Extensions.RequestLimit
+{
+    public class UrlResourceRateLimitContributor : IClientResolveContributor
+    {
+        public static string UrlResource;
+
+        private IHttpContextAccessor httpContextAccessor;
+
+        public UrlResourceRateLimitContributor(IHttpContextAccessor httpContextAccessor)
+        {
+            this.httpContextAccessor = httpContextAccessor;
+        }
+
+        public string ResolveClient()
+        {
+            string clientId = null;
+
+            string[] urlSections = this.httpContextAccessor.HttpContext.Request.Path.Value?.Split('/');
+
+            for (int urlSectionPosition = 0; urlSectionPosition < urlSections.Length && clientId == null; urlSectionPosition++)
+            {
+                if (urlSections[urlSectionPosition] == UrlResource)
+                {
+                    clientId = urlSections[urlSectionPosition + 1];
+                }
+            }
+
+            return clientId;
+        }
+    }
+}

--- a/AspNetScaffolding3/Startup.cs
+++ b/AspNetScaffolding3/Startup.cs
@@ -50,8 +50,19 @@ namespace AspNetScaffolding
             Api.ConfigurationRoot.GetSection("DatabaseSettings").Bind(Api.DatabaseSettings);
             Api.ConfigurationRoot.GetSection("DocsSettings").Bind(Api.DocsSettings);
             Api.ConfigurationRoot.GetSection("ShutdownSettings").Bind(Api.ShutdownSettings);
-            Api.ConfigurationRoot.GetSection("IpRateLimiting").Bind(Api.IpRateLimitingAdditional);
             Api.ConfigurationRoot.GetSection("CacheSettings").Bind(Api.CacheSettings);
+
+            //Create this lógic to keep retrocompatibility because we change the IpRateLimiting section name to RateLimiting
+            var ipRateLimitingSection = Api.ConfigurationRoot.GetSection("IpRateLimiting");
+
+            if (ipRateLimitingSection.Exists())
+            {
+                ipRateLimitingSection.Bind(Api.RateLimitingAdditional);
+            }
+            else
+            {
+                Api.ConfigurationRoot.GetSection("RateLimiting").Bind(Api.RateLimitingAdditional);
+            }
         }
 
         public void ConfigureServices(IServiceCollection services)
@@ -62,7 +73,7 @@ namespace AspNetScaffolding
             services.AddOptions();
             services.SetupCache(Api.CacheSettings);
 
-            services.SetupIpRateLimiting(Api.IpRateLimitingAdditional, Api.CacheSettings);
+            services.SetupIpRateLimiting(Api.RateLimitingAdditional, Api.CacheSettings);
             services.SetupSwaggerDocs(Api.DocsSettings, Api.ApiSettings);
 
             services.AddControllers(mvc => { mvc.EnableEndpointRouting = false; });
@@ -135,7 +146,7 @@ namespace AspNetScaffolding
                 app.UseStaticFiles(path);
             }
             
-            if (Api.IpRateLimitingAdditional?.Enabled == true)
+            if (Api.RateLimitingAdditional?.Enabled == true)
             {
                 app.UseIpRateLimiting();
             }

--- a/AspNetScaffolding3/appsettings.json
+++ b/AspNetScaffolding3/appsettings.json
@@ -48,7 +48,7 @@
     "CacheTtlInSeconds": 900,
     "CacheDb": 0
   },
-  "IpRateLimiting": {
+  "RateLimiting": {
     "Enabled": false,
     "EnableEndpointRateLimiting": false,
     "StackBlockedRequests": false,
@@ -58,6 +58,8 @@
     "IpWhitelist": [],
     "EndpointWhitelist": [],
     "ClientWhitelist": [],
+    "ByUrlResource": false,
+    "UrlResource": "",
     "GeneralRules": [
       {
         "Endpoint": "*",

--- a/README.md
+++ b/README.md
@@ -144,9 +144,11 @@ App Settings
     "MaxThreads": 200,
     "AutoAckOnSuccess": true
   },
-  "IpRateLimiting": {
+  "RateLimiting": {
     "Enabled" : true,
     "EnableEndpointRateLimiting": false,
+    "ByUrlResource": false,
+    "UrlResource": "",
     "StackBlockedRequests": false,
     "RealIpHeader": "X-Real-IP",
     "ClientIdHeader": "X-ClientId",


### PR DESCRIPTION

![Git Merge](https://media.giphy.com/media/VmkZaVwILX161Gkzoz/giphy.gif)

### Status

READY

### Whats?

- Add Rate limiting by resource url. It means that we can choose a resource on our url endpoint to use it as a key to rate limiting.
For exemple: 
endpoint -> `..api/v1/orders/order_id`
If the configuration on appsettings are with `"UrlResource" : "orders"`. We will look for it on the url path and get the value of it. So we will metch the `orders` and get the `order_id` of it to use as key to limit requests

### Evidences
appsettings configuration with 2 requests per minute only allowed
![](https://imgur.com/WG1tri0.jpg)

Before requests
![](https://imgur.com/mvpzK2Z.jpg)

First and second request
![](https://imgur.com/v74GWDP.jpg)

Third request
![](https://imgur.com/6K5geYf.jpg)

Changed the id and send it again
![](https://imgur.com/oOXMxUE.jpg)