### PR TITLE
:sparkles: Adds HttpContext masking and InformationTitle

### DIFF
--- a/AspNetScaffolding3.sln
+++ b/AspNetScaffolding3.sln
@@ -29,6 +29,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "devops", "devops", "{F554D0
 		azure-pipelines.yml = azure-pipelines.yml
 	EndProjectSection
 EndProject
+uProject("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AspNetScaffolding3Tests", "AspNetScaffolding3Tests\AspNetScaffolding3Tests.csproj", "{BB3602B0-49B1-43F3-A574-A10199F18204}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -43,6 +45,10 @@ Global
 		{7852D13E-020D-47CF-97A2-6E84F43AD41D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7852D13E-020D-47CF-97A2-6E84F43AD41D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7852D13E-020D-47CF-97A2-6E84F43AD41D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BB3602B0-49B1-43F3-A574-A10199F18204}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BB3602B0-49B1-43F3-A574-A10199F18204}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BB3602B0-49B1-43F3-A574-A10199F18204}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BB3602B0-49B1-43F3-A574-A10199F18204}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/AspNetScaffolding3/AspNetScaffolding3.csproj
+++ b/AspNetScaffolding3/AspNetScaffolding3.csproj
@@ -36,9 +36,8 @@
     <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="3.1.1" />
     <PackageReference Include="AspNetCore.HealthChecks.Uris" Version="3.1.2" />
     <PackageReference Include="AspNetCoreRateLimit" Version="3.2.2" />
-    <PackageReference Include="AspNetSerilog" Version="1.6.0-preview.2" />
+    <PackageReference Include="AspNetSerilog" Version="1.6.0" />
     <PackageReference Include="AutoMapper" Version="9.0.0" />
-    <PackageReference Include="CQRS.Extensions" Version="3.0.6" />
     <PackageReference Include="CQRS.Extensions.AspNetMVC" Version="3.0.6" />
     <PackageReference Include="Dapper" Version="2.0.123" />
     <PackageReference Include="Easy.Elasticsearch.BulkAndSearch" Version="1.3.0" />

--- a/AspNetScaffolding3/AspNetScaffolding3.csproj
+++ b/AspNetScaffolding3/AspNetScaffolding3.csproj
@@ -36,7 +36,7 @@
     <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="3.1.1" />
     <PackageReference Include="AspNetCore.HealthChecks.Uris" Version="3.1.2" />
     <PackageReference Include="AspNetCoreRateLimit" Version="3.2.2" />
-    <PackageReference Include="AspNetSerilog" Version="1.5.0" />
+    <PackageReference Include="AspNetSerilog" Version="1.6.0-preview.2" />
     <PackageReference Include="AutoMapper" Version="9.0.0" />
     <PackageReference Include="CQRS.Extensions" Version="3.0.6" />
     <PackageReference Include="CQRS.Extensions.AspNetMVC" Version="3.0.6" />

--- a/AspNetScaffolding3/Extensions/Logger/LoggerService.cs
+++ b/AspNetScaffolding3/Extensions/Logger/LoggerService.cs
@@ -48,7 +48,7 @@ namespace AspNetScaffolding.Extensions.Logger
                 BlacklistRequest = settings?.GetJsonBlacklistRequest(),
                 BlacklistResponse = settings?.JsonBlacklistResponse,
                 HeaderBlacklist = settings?.HeaderBlacklist,
-                //HttpContextBlacklist = settings?.HttpContextBlacklist,
+                HttpContextBlacklist = settings?.HttpContextBlacklist,
                 QueryStringBlacklist = settings?.QueryStringBlacklist,
                 RequestKeyProperty = RequestKeyServiceExtension.RequestKeyHeaderName,
                 AccountIdProperty = AccountIdServiceExtension.AccountIdHeaderName,

--- a/AspNetScaffolding3/Extensions/Logger/LoggerService.cs
+++ b/AspNetScaffolding3/Extensions/Logger/LoggerService.cs
@@ -43,11 +43,12 @@ namespace AspNetScaffolding.Extensions.Logger
             var config = new SerilogConfiguration
             {
                 Version = Api.ApiSettings.BuildVersion,
-                InformationTitle = settings?.TitlePrefix + CommunicationLogger.DefaultInformationTitle,
-                ErrorTitle = settings?.TitlePrefix + CommunicationLogger.DefaultErrorTitle,
+                InformationTitle = settings?.TitlePrefix + settings?.GetInformationTitle(),
+                ErrorTitle = settings?.TitlePrefix + settings?.GetErrorTitle(),
                 BlacklistRequest = settings?.GetJsonBlacklistRequest(),
                 BlacklistResponse = settings?.JsonBlacklistResponse,
                 HeaderBlacklist = settings?.HeaderBlacklist,
+                //HttpContextBlacklist = settings?.HttpContextBlacklist,
                 QueryStringBlacklist = settings?.QueryStringBlacklist,
                 RequestKeyProperty = RequestKeyServiceExtension.RequestKeyHeaderName,
                 AccountIdProperty = AccountIdServiceExtension.AccountIdHeaderName,

--- a/AspNetScaffolding3/Extensions/Logger/LoggerSettings.cs
+++ b/AspNetScaffolding3/Extensions/Logger/LoggerSettings.cs
@@ -1,6 +1,7 @@
 ﻿using Serilog.Builder.Models;
 using System;
 using System.Linq;
+using AspNetSerilog;
 
 namespace AspNetScaffolding.Extensions.Logger
 {
@@ -29,7 +30,13 @@ namespace AspNetScaffolding.Extensions.Logger
         public string[] JsonBlacklistResponse { get; set; }
 
         public string[] HeaderBlacklist { get; set; }
+        
+        public string[] HttpContextBlacklist { get; set; }
 
+        public string InformationTitle { get; set; }
+
+        public string ErrorTitle { get; set; }
+        
         public string[] QueryStringBlacklist { get; set; }
 
         public bool DebugEnabled { get; set; }
@@ -41,5 +48,21 @@ namespace AspNetScaffolding.Extensions.Logger
         public NewRelicOptions NewRelicOptions { get; set; } = new NewRelicOptions();
 
         public DataDogOptions DataDogOptions { get; set; } = new DataDogOptions();
+        
+        public string GetInformationTitle()
+        {
+            if (string.IsNullOrWhiteSpace(InformationTitle))
+                return CommunicationLogger.DefaultInformationTitle;
+
+            return InformationTitle;
+        }
+        
+        public string GetErrorTitle()
+        {
+            if (string.IsNullOrWhiteSpace(ErrorTitle))
+                return CommunicationLogger.DefaultErrorTitle;
+
+            return ErrorTitle;
+        }
     }
 }

--- a/AspNetScaffolding3Tests/AspNetScaffolding3Tests.csproj
+++ b/AspNetScaffolding3Tests/AspNetScaffolding3Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+        <PackageReference Include="xunit" Version="2.4.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="3.0.2">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\AspNetScaffolding3\AspNetScaffolding3.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/AspNetScaffolding3Tests/Extensions/Logger/LoggerSettingsTest.cs
+++ b/AspNetScaffolding3Tests/Extensions/Logger/LoggerSettingsTest.cs
@@ -26,7 +26,7 @@ namespace AspNetScaffolding3Tests.Extensions.Logger
         }
 
         [Fact]
-        public void GetInformationTitle_InformationTitleEqualNull_ReturnDefaundValue()
+        public void GetInformationTitle_InformationTitleEqualNull_ReturnDefaultValue()
         {
             var expected = "HTTP {Method} {Path} from {Ip} responded {StatusCode} in {ElapsedMilliseconds} ms";
             var actual = _loggerSettings.GetInformationTitle();
@@ -35,7 +35,7 @@ namespace AspNetScaffolding3Tests.Extensions.Logger
         }
         
         [Fact]
-        public void GetInformationTitle_InformationTitleEqualEmpty_ReturnDefaundValue()
+        public void GetInformationTitle_InformationTitleEqualEmpty_ReturnDefaultValue()
         {
             var informationTitle = " ";
             _loggerSettings.InformationTitle = informationTitle;
@@ -59,7 +59,7 @@ namespace AspNetScaffolding3Tests.Extensions.Logger
         }
 
         [Fact]
-        public void GetErrorTitle_ErrorTitleEqualNull_ReturnDefaundValue()
+        public void GetErrorTitle_ErrorTitleEqualNull_ReturnDefaultValue()
         {
             var expected = "HTTP {Method} {Path} from {Ip} responded {StatusCode} in {ElapsedMilliseconds} ms";
             var actual = _loggerSettings.GetErrorTitle();
@@ -68,7 +68,7 @@ namespace AspNetScaffolding3Tests.Extensions.Logger
         }
         
         [Fact]
-        public void GetErrorTitle_ErrorTitleEqualEmpty_ReturnDefaundValue()
+        public void GetErrorTitle_ErrorTitleEqualEmpty_ReturnDefaultValue()
         {
             var informationTitle = " ";
             _loggerSettings.ErrorTitle = informationTitle;

--- a/AspNetScaffolding3Tests/Extensions/Logger/LoggerSettingsTest.cs
+++ b/AspNetScaffolding3Tests/Extensions/Logger/LoggerSettingsTest.cs
@@ -1,0 +1,82 @@
+using AspNetScaffolding.Extensions.Logger;
+
+using Xunit;
+
+namespace AspNetScaffolding3Tests.Extensions.Logger
+{
+    public class LoggerSettingsTest
+    {
+        private LoggerSettings _loggerSettings;
+
+        public LoggerSettingsTest()
+        {
+            _loggerSettings = new LoggerSettings();
+        }
+
+        [Fact]
+        public void GetInformationTitle_InformingInformationTitle_ReturnsInformedValue()
+        {
+            var informationTitle = "Information Title";
+            _loggerSettings.InformationTitle = informationTitle;
+
+            var expected = informationTitle;
+            var actual = _loggerSettings.GetInformationTitle();
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void GetInformationTitle_InformationTitleEqualNull_ReturnDefaundValue()
+        {
+            var expected = "HTTP {Method} {Path} from {Ip} responded {StatusCode} in {ElapsedMilliseconds} ms";
+            var actual = _loggerSettings.GetInformationTitle();
+
+            Assert.Equal(expected, actual);
+        }
+        
+        [Fact]
+        public void GetInformationTitle_InformationTitleEqualEmpty_ReturnDefaundValue()
+        {
+            var informationTitle = " ";
+            _loggerSettings.InformationTitle = informationTitle;
+
+            var expected = "HTTP {Method} {Path} from {Ip} responded {StatusCode} in {ElapsedMilliseconds} ms";
+            var actual = _loggerSettings.GetInformationTitle();
+
+            Assert.Equal(expected, actual);
+        }
+        
+         [Fact]
+        public void GetErrorTitle_ErrorTitleTitle_ReturnsInformedValue()
+        {
+            var errorTitle = "Error Title";
+            _loggerSettings.ErrorTitle = errorTitle;
+
+            var expected = errorTitle;
+            var actual = _loggerSettings.GetErrorTitle();
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void GetErrorTitle_ErrorTitleEqualNull_ReturnDefaundValue()
+        {
+            var expected = "HTTP {Method} {Path} from {Ip} responded {StatusCode} in {ElapsedMilliseconds} ms";
+            var actual = _loggerSettings.GetErrorTitle();
+
+            Assert.Equal(expected, actual);
+        }
+        
+        [Fact]
+        public void GetErrorTitle_ErrorTitleEqualEmpty_ReturnDefaundValue()
+        {
+            var informationTitle = " ";
+            _loggerSettings.ErrorTitle = informationTitle;
+
+            var expected = "HTTP {Method} {Path} from {Ip} responded {StatusCode} in {ElapsedMilliseconds} ms";
+            var actual = _loggerSettings.GetErrorTitle();
+
+            Assert.Equal(expected, actual);
+        }
+    }
+}


### PR DESCRIPTION
Whats?
Implements a way to mask fields in the HttpContext.

Why?
Because it is needed to mask some fields when logging information present in http context.

How?
Added new methods to handle the field masking.
Added fields in the configuration file to store and separate the fields that we need to mask.