### PR TITLE
[Bugfix] Force validation child properties in fluent validation

### DIFF
--- a/AspNetScaffolding3/Extensions/Mvc/MvcBuilderExtension.cs
+++ b/AspNetScaffolding3/Extensions/Mvc/MvcBuilderExtension.cs
@@ -21,7 +21,8 @@ namespace AspNetScaffolding.Extensions.RequestKey
             mvc.AddFluentValidation(fluent =>
             {
                 fluent.RegisterValidatorsFromAssemblyContaining<Startup>();
-
+                fluent.ImplicitlyValidateChildProperties = true;
+                
                 if (assemblies?.Any() == true)
                 {
                     fluent.RegisterValidatorsFromAssemblies(assemblies);


### PR DESCRIPTION
![Git Merge](https://media.giphy.com/media/cFkiFMDg3iFoI/giphy.gif)

### Status

READY

### Whats?

If the project is using net6, validations with fluentvalidation stop working

### Why?

Keep the behavior already established, since the creation of scaffolding3
