### PR TITLE
fix: disable serilog default Console log when Stdout sink is enabled

### DIFF
--- a/AspNetScaffolding3/Extensions/Logger/LoggerBuilderExtension.cs
+++ b/AspNetScaffolding3/Extensions/Logger/LoggerBuilderExtension.cs
@@ -3,20 +3,32 @@
 using AspNetScaffolding3.Extensions.Logger.Formatters;
 
 using Serilog;
+using Serilog.Builder;
 using Serilog.Formatting.Json;
 
 namespace AspNetScaffolding3.Extensions.Logger
 {
     public static class LoggerBuilderExtension
     {
+        public static LoggerBuilder DisableConsoleIfConsoleSinkIsEnabled(this LoggerBuilder loggerBuilder, ScaffoldingConsoleOptions? consoleOptions = null)
+        {
+            if (consoleOptions?.Enabled ?? false)
+            {
+                loggerBuilder.DisableConsole();
+            }
+
+            return loggerBuilder;
+        }
+
         public static LoggerConfiguration EnableStdOutput(this LoggerConfiguration loggerConfiguration, ScaffoldingConsoleOptions consoleOptions = null)
         {
             if (consoleOptions?.Enabled ?? false)
             {
+                var minimmumLevel = consoleOptions.MinimumLevel ?? Serilog.Events.LogEventLevel.Verbose;
                 return consoleOptions.FormatterType switch
                 {
-                    EConsoleEnricherFormatter.SnakeCase => loggerConfiguration.WriteTo.Console(new SnakeCaseRenderedCompactJsonFormatter()).Enrich.FromLogContext(),
-                    _ => loggerConfiguration.WriteTo.Console(formatter: new JsonFormatter()).Enrich.FromLogContext(),
+                    EConsoleEnricherFormatter.SnakeCase => loggerConfiguration.WriteTo.Console(new SnakeCaseRenderedCompactJsonFormatter(), minimmumLevel).Enrich.FromLogContext(),
+                    _ => loggerConfiguration.WriteTo.Console(formatter: new JsonFormatter(), minimmumLevel).Enrich.FromLogContext(),
                 };
             }
 

--- a/AspNetScaffolding3/Extensions/Logger/LoggerService.cs
+++ b/AspNetScaffolding3/Extensions/Logger/LoggerService.cs
@@ -34,6 +34,7 @@ namespace AspNetScaffolding.Extensions.Logger
                 .SetupSplunk(settings?.SplunkOptions)
                 .SetupNewRelic(settings?.NewRelicOptions)
                 .SetupDataDog(settings?.DataDogOptions)
+                .DisableConsoleIfConsoleSinkIsEnabled(settings?.ConsoleOptions)
                 .BuildConfiguration()
                 .EnableStdOutput(settings?.ConsoleOptions)
                 .CreateLogger();


### PR DESCRIPTION
![Git Merge](https://media.giphy.com/media/cFkiFMDg3iFoI/giphy.gif)

### Status

READY

### Whats?

1. Disable Serilog Console log(enabled by default in `Serilog.Builder.LoggerBuilder.UseSuggestedSetting(string domain, string application)`) if settings has Console logging enabled.
2. Respect `MinimumLevel` in Console Sink

### Why?

The DataDog, by default, understand the first received log and set the formatter based on it, the json format of log is not recognized after the first formatter has setted, removing the duplicated logs and manteining only the formatted as json one, the datadog will be recognize the json properties