### PR TITLE
[Feature] Adds setup lapi configs!

### DIFF
--- a/AspNetScaffolding3/AspNetScaffolding3.csproj
+++ b/AspNetScaffolding3/AspNetScaffolding3.csproj
@@ -55,7 +55,7 @@
     <PackageReference Include="RedLock.net" Version="2.3.1" />
     <PackageReference Include="RestSharp.Easy" Version="1.5.1" />
     <PackageReference Include="RestSharp.Serilog.Auto" Version="1.4.0" />
-    <PackageReference Include="Serilog.Builder" Version="1.4.0-preview.1" />
+    <PackageReference Include="Serilog.Builder" Version="1.4.1" />
     <PackageReference Include="SqlClient.ParseToObject" Version="1.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.5.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="5.5.1" />

--- a/AspNetScaffolding3/Extensions/Logger/LoggerService.cs
+++ b/AspNetScaffolding3/Extensions/Logger/LoggerService.cs
@@ -34,6 +34,7 @@ namespace AspNetScaffolding.Extensions.Logger
                 .SetupSplunk(settings?.SplunkOptions)
                 .SetupNewRelic(settings?.NewRelicOptions)
                 .SetupDataDog(settings?.DataDogOptions)
+                .SetupLapi(settings?.LapiOptions)
                 .DisableConsoleIfConsoleSinkIsEnabled(settings?.ConsoleOptions)
                 .BuildConfiguration()
                 .EnableStdOutput(settings?.ConsoleOptions)

--- a/AspNetScaffolding3/Extensions/Logger/LoggerSettings.cs
+++ b/AspNetScaffolding3/Extensions/Logger/LoggerSettings.cs
@@ -49,6 +49,8 @@ namespace AspNetScaffolding.Extensions.Logger
         public NewRelicOptions NewRelicOptions { get; set; } = new NewRelicOptions();
 
         public DataDogOptions DataDogOptions { get; set; } = new DataDogOptions();
+
+        public LapiOptions LapiOptions { get; set; } = new LapiOptions();
         
         public AspNetScaffolding.Extensions.Logger.ScaffoldingConsoleOptions ConsoleOptions { get; set; } = new AspNetScaffolding.Extensions.Logger.ScaffoldingConsoleOptions();
 


### PR DESCRIPTION
![Git Merge](https://media.giphy.com/media/5tvJS6ZZslR9nBYxUA/giphy.gif?cid=790b7611c25prvcwbbh49d2ld2xlpul7s7cpbsd9cnp4yp36&ep=v1_gifs_search&rid=giphy.gif&ct=g)

### Status

READY 

### Whats?

Adds new version to Serilog.Builder and call setup lapi method

### Why?

WalletsApi is losing logs from splunk and after a little analysis, the team informed us that we could be losing logs because we were sending logs direct to splunk. The first suggestion was change the way that logs are sent to splunk just adding Logger Api (LAPI).

### Definition of Done:
- [ ] Increases API documentation
- [ ] Implements integration tests
- [ ] Implements unit tests
- [ ] Is there appropriate logging included?
- [x] Does this add new dependencies?
- [ ] Does need add new version in changelog?
- [ ] Does need update readme, contributing, etc?
- [ ] Does need change in CI server?
- [ ] Will this feature require a new piece of infrastructure be implemented?
- [ ] Does this PR require a blog post? If so, ensure marketing has signed off on content.
