### PR TITLE
feat: add a method to configure controllers

### DIFF
--- a/AspNetScaffolding3/Models/ApiBasicConfiguration.cs
+++ b/AspNetScaffolding3/Models/ApiBasicConfiguration.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Generic;
@@ -25,5 +26,7 @@ namespace AspNetScaffolding.Models
         public Action<IApplicationBuilder> Configure { get; set; }
 
         public Action<IApplicationBuilder> ConfigureAfter { get; set; }
+
+        public Action<MvcOptions> ConfigureControllers { get; set; }
     }
 }

--- a/AspNetScaffolding3/Startup.cs
+++ b/AspNetScaffolding3/Startup.cs
@@ -23,6 +23,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using RestSharp.Serilog.Auto;
 using System;
 using System.Collections.Generic;
@@ -79,7 +80,11 @@ namespace AspNetScaffolding
             services.SetupIpRateLimiting(Api.RateLimitingAdditional, Api.CacheSettings);
             services.SetupSwaggerDocs(Api.DocsSettings, Api.ApiSettings);
 
-            services.AddControllers(mvc => { mvc.EnableEndpointRouting = false; });
+            services.AddControllers(mvc => 
+            { 
+                mvc.EnableEndpointRouting = false;
+                Api.ApiBasicConfiguration?.ConfigureControllers?.Invoke(mvc);
+            });
 
             var mvc = services.AddMvc(options => options.EnableEndpointRouting = false);
             mvc.RegisterAssembliesForControllers(Api.ApiBasicConfiguration?.AutoRegisterAssemblies);


### PR DESCRIPTION
![Git Merge](https://media.giphy.com/media/cFkiFMDg3iFoI/giphy.gif)

### Status

READY

### Whats?

Enable the possibility to configure the MvcOptions, necessary to change some options

### Why?

In some apis working with IAsyncEnumerable, is necessary to change the max serialization buffer size, in property,  MaxIAsyncEnumerableBufferLimit.

### How?

Create a delegate and add it in the ApiBasicConfiguration to enable a possibility to change the MvcOptions in AddControllers method