### PR TITLE
fix: Adding IgnoredRoutes from LogSettings to SetupSerilog

### DIFF
--- a/AspNetScaffolding3/Extensions/Logger/LoggerSettings.cs
+++ b/AspNetScaffolding3/Extensions/Logger/LoggerSettings.cs
@@ -61,6 +61,8 @@ namespace AspNetScaffolding.Extensions.Logger
 
         public Action<IServiceCollection, SerilogConfiguration> SetupSerilog { get; set; }
 
+        public string[] IgnoredRoutes { get; set; }
+
         public string GetInformationTitle()
         {
             if (string.IsNullOrWhiteSpace(InformationTitle))

--- a/AspNetScaffolding3/Startup.cs
+++ b/AspNetScaffolding3/Startup.cs
@@ -115,6 +115,11 @@ namespace AspNetScaffolding
                 ignoredRoutes.Add(HealthcheckkMiddlewareExtension.GetFullPath(Api.ApiSettings, Api.HealthcheckSettings));
             }
 
+            if (Api.LogSettings.IgnoredRoutes?.Count() > 0)
+            {
+                ignoredRoutes.AddRange(Api.LogSettings.IgnoredRoutes?.ToList());
+            }
+
             services.SetupSerilog(Api.ApiSettings?.Domain,
                 Api.ApiSettings?.Application,
                 Api.LogSettings,


### PR DESCRIPTION
![Git Merge](https://media.giphy.com/media/cFkiFMDg3iFoI/giphy.gif)

### Status

READY 

### Whats?

[hotfix] No appsettings existe a propriedade LogSettings.IgnoredRoutes, porém a mesma não estava sendo considerada nas configurações para o método SetupSerilog.

### Why?

Adicionar configuração de ignorar logs para rotas específicas.

### How?

Adicionando a propriedade na classe LoggerSettings.

### Attachments (if appropriate)

![image](https://github.com/user-attachments/assets/434930c2-5e50-4689-aeed-31ac5b71dbce)


![image](https://github.com/user-attachments/assets/5c08bc8c-9ecc-4270-be0a-6c188abb699c)


